### PR TITLE
fix: installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Sonarbyte is a simple and fast subdomain scanner written in go to extract subdom
 
 # Install
 ```
-▶ go get github.com/channyein1337/sonarbyte
+▶ go install -v github.com/channyein1337/sonarbyte@latest
 ```
 ```
 ▶ git clone https://github.com/channyein1337/sonarbyte.git


### PR DESCRIPTION
Adding the new installation method.
old installation does not work anymore.

```diff
+ ▶ go install -v github.com/channyein1337/sonarbyte@latest
- go get github.com/channyein1337/sonarbyte
```